### PR TITLE
Improve terminal command formatting for better copy-paste usability

### DIFF
--- a/.clinerules-code
+++ b/.clinerules-code
@@ -73,7 +73,7 @@ instructions:
     - "     - When explicitly requested by user"
     - "     - When processing a UMB request with no additional instructions"
     - "  3. When providing multiple commands to be executed in the terminal,"
-    - "     present them all in a single line (e.g., 'command1 && command2') so users can copy and paste them directly."
+    - "     present them all in a single line (e.g., 'command1 && command2') so users can copy and paste them directly."   
     - "When a Memory Bank is found:"
     - "  1. Read ALL files in the memory-bank directory"
     - "  2. Check for core Memory Bank files:"

--- a/.clinerules-code
+++ b/.clinerules-code
@@ -72,6 +72,8 @@ instructions:
     - "  2. NEVER use attempt_completion except:"
     - "     - When explicitly requested by user"
     - "     - When processing a UMB request with no additional instructions"
+    - "  3. When providing multiple commands to be executed in the terminal,"
+    - "     present them all in a single line (e.g., 'command1 && command2') so users can copy and paste them directly."
     - "When a Memory Bank is found:"
     - "  1. Read ALL files in the memory-bank directory"
     - "  2. Check for core Memory Bank files:"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ Download and copy these files to your project's **root** directory:
 Create a `projectBrief.md` in your project root **before** initialization to give Roo immediate project context.
 </details>
 
+### File Organization
+
+```
+project-root/
+├── .clinerules-architect
+├── .clinerules-code
+├── .clinerules-ask
+├── memory-bank/
+│   ├── activeContext.md
+│   ├── productContext.md
+│   ├── progress.md
+│   └── decisionLog.md
+└── projectBrief.md
+```
+
 ## 📚 Memory Bank Structure
 
 ```mermaid


### PR DESCRIPTION
Updated the general instructions to ensure terminal commands are presented in a single line using && to facilitate direct copy-pasting.
Added the new rule under "Task Completion Behavior" in the instructions -> general section.
Ensures users can execute multiple commands seamlessly without manual edits.
